### PR TITLE
Backend - Dev Tools - Migration Generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,24 @@
 {
-  "name": "react-express-auth-template",
-  "version": "1.0.0",
-  "description": "",
-  "main": "server/index.js",
-  "scripts": {
-    "kickstart": "cd frontend && npm i && npm run build && cd ../server && npm i && npm run migrate && npm run seed",
-    "build:frontend": "cd frontend && npm i && npm run build",
-    "migrate": "cd server && npm run migrate",
-    "seed": "cd server && npm run seed",
-    "start": "cd server && npm start",
-    "dev": "cd server && npm run dev",
-    "dev:frontend": "cd frontend && npm run dev",
-    "connect": "psql -U postgres -d react_auth_example",
-    "lint": "eslint . --fix"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "dependencies": {
-    "knex": "^3.1.0"
-  }
+	"name": "react-express-auth-template",
+	"version": "1.0.0",
+	"description": "",
+	"main": "server/index.js",
+	"scripts": {
+		"kickstart": "cd frontend && npm i && npm run build && cd ../server && npm i && npm run migrate && npm run seed",
+		"build:frontend": "cd frontend && npm i && npm run build",
+		"migrate": "cd server && npm run migrate",
+		"migrate:make": "cd server && npx knex migrate:make",
+		"seed": "cd server && npm run seed",
+		"start": "cd server && npm start",
+		"dev": "cd server && npm run dev",
+		"dev:frontend": "cd frontend && npm run dev",
+		"connect": "psql -U postgres -d react_auth_example",
+		"lint": "eslint . --fix"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"dependencies": {
+		"knex": "^3.1.0"
+	}
 }


### PR DESCRIPTION
This PR was made to add a command that will make our lives easier.

I added the `"migrate:make"` command into our package.json so that we can run something like `npm run migrate:make user_posts_table` from the root directory. 
> Without this command we would have to cd into our server first before we run `npx knex migrate:make file_name` Of course, you can still do that if you want... but I just made it easy!!!

With this we can easily create new migration files instead of using the `migrate:rollback` command. Since we were advised against using the `migrate:rollback` command to create/edit our tables lets just follow the suggestion and use this command instead

TL;DR
DO NOT `npx knex migrate:rollback`
DO `npm run migrate:make file_name`