### PR TITLE
Repo maintenance usage and misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,54 @@
+<!-- @format -->
+
 # CopCheck
 
 Our application is tailored for citizens who may have had a run-in with law enforcement or anyone wanting to make a change, such as community activists, residents in high-police areas, and those involved in legal matters. Users can see officers at the nearest precinct based on their location, empowering them to be more informed and engaged. They can leave detailed reports or complaints about their experiences with specific officers, ensuring their voices are heard. Also, users can upload videos of interactions, providing crucial evidence of potential misconduct and injustices. The app also allows users to look up police officers by name and badge number, giving access to data on previous interactions and their community scores, fostering transparency and accountability within law enforcement.
 
-
 ## Team
 
-  - __Project Manager__: Mekhi Tudor
-  - __Scrum Master__: Mekhi Miller
-  - __Development Team Members__: Patrick Dacius, Mekhi Tudor, Mekhi Miller
+- **Project Manager**: Mekhi Tudor
+- **Scrum Master**: Mekhi Miller
+- **Development Team Members**: Patrick Dacius, Mekhi Tudor, Mekhi Miller
 
 ## Table of Contents
 
 1. [Usage](#Usage)
 1. [Requirements](#requirements)
 1. [Development](#development)
-    1. [Installing Dependencies](#installing-dependencies)
-    1. [Tasks](#tasks)
+   1. [Installing Dependencies](#installing-dependencies)
+   1. [Tasks](#tasks)
 1. [Team](#team)
 1. [Contributing](#contributing)
 
 ## Usage
 
-> Some usage instructions for getting the app up and running locally
+1. Fork this repo and clone it to your PC locally.
+
+2. Create a new Postgres database called `copcheck` locally on your computer.
+
+3. In the `server/` folder, copy the `.env.template` and name it `.env`.
+
+   - Update the `.env` variables to match your Postgres database information (username, password, database name)
+   - Replace the `SESSION_SECRET` value with your own random string. This is used to encrypt the cookie's `userId` value.
+
+- Your `.env` file should look something like this:
+
+```sh
+# Replace these variables with your Postgres server information
+# These values are used by knexfile.js to connect to your postgres server
+PG_HOST='127.0.0.1'
+PG_PORT=5432
+PG_USER='itsamemario'
+PG_PASS='12345'
+PG_DB='copcheck'
+
+# Replace session secret with your own random string!
+# This is used by handleCookieSessions to encrypt your
+SESSION_SECRET='db8c3cffebb2159b46ee38ded600f437ee080f8605510ee360758f6976866e00d603d9b3399341b0cd37dfb8e599fff3'
+PG_CONNECTION_STRING=''
+```
+
+4. See the ["Development"](#development) section of this repo for instructions on what commands to run locally.
 
 ## Requirements
 
@@ -45,11 +72,9 @@ From within the root directory:
 
 View the project roadmap [here](https://github.com/orgs/TEAM-3PM/projects/1).
 
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
-
 
 ## Style Guide
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "react-express-auth-template",
+	"name": "cop-check",
 	"version": "1.0.0",
 	"description": "",
 	"main": "server/index.js",
@@ -12,7 +12,7 @@
 		"start": "cd server && npm start",
 		"dev": "cd server && npm run dev",
 		"dev:frontend": "cd frontend && npm run dev",
-		"connect": "psql -U postgres -d react_auth_example",
+		"connect": "psql -U postgres -d copcheck",
 		"lint": "eslint . --fix"
 	},
 	"keywords": [],

--- a/server/.env.template
+++ b/server/.env.template
@@ -1,0 +1,11 @@
+# Replace these variables with your Postgres server information
+# These values are used by knexfile.js to connect to your postgres server
+PG_HOST='127.0.0.1'
+PG_PORT=5432
+PG_USER='postgres'
+PG_PASS=''
+PG_DB='copcheck'
+# Replace session secret with your own random string!
+# This is used by handleCookieSessions to encrypt your 
+SESSION_SECRET='db8c3cffebb2159b46ee38ded600f437ee080f8605510ee360758f6976866e00d603d9b3399341b0cd37dfb8e599fff3'
+PG_CONNECTION_STRING=''

--- a/server/knexfile.js
+++ b/server/knexfile.js
@@ -1,3 +1,5 @@
+/** @format */
+
 require("dotenv").config();
 const path = require("path");
 
@@ -12,30 +14,30 @@ When we deploy in "production", we'll provide a PG_CONNECTION_STRING
 */
 
 module.exports = {
-  development: {
-    client: "pg",
-    connection: process.env.PG_CONNECTION_STRING || {
-      host: process.env.PG_HOST || "127.0.0.1",
-      port: process.env.PG_PORT || 5432,
-      user: process.env.PG_USER || "marcy",
-      password: process.env.PG_PASS || "",
-      database: process.env.PG_DB || "copcheck",
-    },
-    migrations: {
-      directory: migrationsDirectory,
-    },
-    seeds: {
-      directory: seedsDirectory,
-    },
-  },
-  production: {
-    client: "pg",
-    connection: process.env.PG_CONNECTION_STRING,
-    migrations: {
-      directory: migrationsDirectory,
-    },
-    seeds: {
-      directory: seedsDirectory,
-    },
-  },
+	development: {
+		client: "pg",
+		connection: process.env.PG_CONNECTION_STRING || {
+			host: process.env.PG_HOST || "127.0.0.1",
+			port: process.env.PG_PORT || 5432,
+			user: process.env.PG_USER || "postgres",
+			password: process.env.PG_PASS || "",
+			database: process.env.PG_DB || "copcheck",
+		},
+		migrations: {
+			directory: migrationsDirectory,
+		},
+		seeds: {
+			directory: seedsDirectory,
+		},
+	},
+	production: {
+		client: "pg",
+		connection: process.env.PG_CONNECTION_STRING,
+		migrations: {
+			directory: migrationsDirectory,
+		},
+		seeds: {
+			directory: seedsDirectory,
+		},
+	},
 };

--- a/server/package.json
+++ b/server/package.json
@@ -1,41 +1,41 @@
 {
-  "name": "react-express-auth-template",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "build": "npm i && npm run migrate:rollback && npm run migrate && npm run seed",
-    "start": "node ./index.js",
-    "dev": "nodemon ./index.js",
-    "connect": "psql -U marcy -d copcheck",
-    "migrate": "knex migrate:latest",
-    "migrate:make": "knex migrate:make",
-    "migrate:rollback": "knex migrate:rollback",
-    "seed": "knex seed:run",
-    "seed:make": "knex seed:make",
-    "lint": "eslint . --fix"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "dependencies": {
-    "bcrypt": "^5.1.0",
-    "connect-session-knex": "^3.0.1",
-    "cookie-parser": "^1.4.6",
-    "cookie-session": "^2.0.0",
-    "dotenv": "^16.0.3",
-    "express": "^4.21.0",
-    "express-session": "^1.17.3",
-    "knex": "^2.4.2",
-    "pg": "^8.10.0"
-  },
-  "devDependencies": {
-    "eslint": "^8.39.0",
-    "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-react": "^7.32.2",
-    "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.3.4",
-    "nodemon": "^2.0.22"
-  }
+	"name": "cop-check",
+	"version": "1.0.0",
+	"description": "",
+	"main": "index.js",
+	"scripts": {
+		"build": "npm i && npm run migrate:rollback && npm run migrate && npm run seed",
+		"start": "node ./index.js",
+		"dev": "nodemon ./index.js",
+		"connect": "psql -U postgres -d copcheck",
+		"migrate": "knex migrate:latest",
+		"migrate:make": "knex migrate:make",
+		"migrate:rollback": "knex migrate:rollback",
+		"seed": "knex seed:run",
+		"seed:make": "knex seed:make",
+		"lint": "eslint . --fix"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"dependencies": {
+		"bcrypt": "^5.1.0",
+		"connect-session-knex": "^3.0.1",
+		"cookie-parser": "^1.4.6",
+		"cookie-session": "^2.0.0",
+		"dotenv": "^16.0.3",
+		"express": "^4.21.0",
+		"express-session": "^1.17.3",
+		"knex": "^2.4.2",
+		"pg": "^8.10.0"
+	},
+	"devDependencies": {
+		"eslint": "^8.39.0",
+		"eslint-config-airbnb-base": "^15.0.0",
+		"eslint-plugin-import": "^2.27.5",
+		"eslint-plugin-react": "^7.32.2",
+		"eslint-plugin-react-hooks": "^4.6.0",
+		"eslint-plugin-react-refresh": "^0.3.4",
+		"nodemon": "^2.0.22"
+	}
 }


### PR DESCRIPTION
This PR does the following:
- Completes the `READ.ME` with the Usage section
- Reinstates the `.env.template` file to fit the contents of the Usage section in the `READ.ME`
- Changes the contents of any package.json files in the repo to have the repo name as the name property
- Makes it so any psql stuff has `postgres` as the user and `copcheck` as the database
- change 1 word in the contributing file cuz idk ngl just felt like it sounded better